### PR TITLE
updated env v1

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -24,37 +24,37 @@ services:
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
       # dspace.dir, dspace.server.url and dspace.ui.url
       dspace__P__dir: /dspace
-      dspace__P__server__P__url: http://localhost:8080/server
-      dspace__P__ui__P__url: http://localhost:4000
+      dspace__P__server__P__url: http://172.31.86.154:8080/server
+      dspace__P__ui__P__url: http://172.31.86.154:4000
       # db.url: Ensure we are using the 'dspacedb' image for our database
       db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
       # solr.server: Ensure we are using the 'dspacesolr' image for Solr
       solr__P__server: http://dspacesolr:8983/solr
     depends_on:
-    - dspacedb
+      - dspacedb
     image: dspace/dspace:dspace-7_x-test
     networks:
       dspacenet:
     ports:
-    - published: 8080
-      target: 8080
+      - published: 8080
+        target: 8080
     stdin_open: true
     tty: true
     volumes:
-    - assetstore:/dspace/assetstore
-    # Mount DSpace's solr configs to a volume, so that we can share to 'dspacesolr' container (see below)
-    - solr_configs:/dspace/solr
-    # Ensure that the database is ready BEFORE starting tomcat
-    # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
-    # 2. Then, run database migration to init database tables (including any out-of-order ignored migrations, if any)
-    # 3. Finally, start Tomcat
+      - assetstore:/dspace/assetstore
+      # Mount DSpace's solr configs to a volume, so that we can share to 'dspacesolr' container (see below)
+      - solr_configs:/dspace/solr
+      # Ensure that the database is ready BEFORE starting tomcat
+      # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
+      # 2. Then, run database migration to init database tables (including any out-of-order ignored migrations, if any)
+      # 3. Finally, start Tomcat
     entrypoint:
-    - /bin/bash
-    - '-c'
-    - |
-      while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
-      /dspace/bin/dspace database migrate ignored
-      catalina.sh run
+      - /bin/bash
+      - '-c'
+      - |
+        while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
+        /dspace/bin/dspace database migrate ignored
+        catalina.sh run
   # DSpace database container
   # NOTE: This is customized to use our loadsql image, so that we are using a database with existing test data
   dspacedb:
@@ -71,7 +71,7 @@ services:
     stdin_open: true
     tty: true
     volumes:
-    - pgdata:/pgdata
+      - pgdata:/pgdata
   # DSpace Solr container
   dspacesolr:
     container_name: dspacesolr
@@ -79,35 +79,34 @@ services:
     image: solr:8.11-slim
     # Needs main 'dspace' container to start first to guarantee access to solr_configs
     depends_on:
-    - dspace
+      - dspace
     networks:
       dspacenet:
     ports:
-    - published: 8983
-      target: 8983
+      - published: 8983
+        target: 8983
     stdin_open: true
     tty: true
     working_dir: /var/solr/data
     volumes:
-    # Mount our "solr_configs" volume available under the Solr's configsets folder (in a 'dspace' subfolder)
-    # This copies the Solr configs from main 'dspace' container into 'dspacesolr' via that volume
-    - solr_configs:/opt/solr/server/solr/configsets/dspace
-    # Keep Solr data directory between reboots
-    - solr_data:/var/solr/data
-    # Initialize all DSpace Solr cores using the mounted configsets (see above), then start Solr
+      # Mount our "solr_configs" volume available under the Solr's configsets folder (in a 'dspace' subfolder)
+      - solr_configs:/opt/solr/server/solr/configsets/dspace
+      # Keep Solr data directory between reboots
+      - solr_data:/var/solr/data
+      # Initialize all DSpace Solr cores using the mounted configsets (see above), then start Solr
     entrypoint:
-    - /bin/bash
-    - '-c'
-    - |
-      init-var-solr
-      precreate-core authority /opt/solr/server/solr/configsets/dspace/authority
-      precreate-core oai /opt/solr/server/solr/configsets/dspace/oai
-      precreate-core search /opt/solr/server/solr/configsets/dspace/search
-      precreate-core statistics /opt/solr/server/solr/configsets/dspace/statistics
-      exec solr -f
+      - /bin/bash
+      - '-c'
+      - |
+        init-var-solr
+        precreate-core authority /opt/solr/server/solr/configsets/dspace/authority
+        precreate-core oai /opt/solr/server/solr/configsets/dspace/oai
+        precreate-core search /opt/solr/server/solr/configsets/dspace/search
+        precreate-core statistics /opt/solr/server/solr/configsets/dspace/statistics
+        exec solr -f
 volumes:
   assetstore:
   pgdata:
-  solr_data:
-  # Special volume used to share Solr configs from 'dspace' to 'dspacesolr' container (see above)
+  solr_data: # Special volume used to share Solr configs from 'dspace' to 'dspacesolr' container (see above)
+
   solr_configs:

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -29,8 +29,8 @@ services:
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
       # dspace.dir, dspace.server.url, dspace.ui.url and dspace.name
       dspace__P__dir: /dspace
-      dspace__P__server__P__url: http://localhost:8080/server
-      dspace__P__ui__P__url: http://localhost:4000
+      dspace__P__server__P__url: http://172.31.86.154:8080/server
+      dspace__P__ui__P__url: http://172.31.86.154:4000
       dspace__P__name: 'DSpace Started with Docker Compose'
       # db.url: Ensure we are using the 'dspacedb' image for our database
       db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
@@ -41,29 +41,29 @@ services:
       proxies__P__trusted__P__ipranges: '172.23.0'
     image: dspace/dspace:dspace-7_x-test
     depends_on:
-    - dspacedb
+      - dspacedb
     networks:
       dspacenet:
     ports:
-    - published: 8080
-      target: 8080
+      - published: 8080
+        target: 8080
     stdin_open: true
     tty: true
     volumes:
-    - assetstore:/dspace/assetstore
-    # Mount DSpace's solr configs to a volume, so that we can share to 'dspacesolr' container (see below)
-    - solr_configs:/dspace/solr
-    # Ensure that the database is ready BEFORE starting tomcat
-    # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
-    # 2. Then, run database migration to init database tables
-    # 3. Finally, start Tomcat
+      - assetstore:/dspace/assetstore
+      # Mount DSpace's solr configs to a volume, so that we can share to 'dspacesolr' container (see below)
+      - solr_configs:/dspace/solr
+      # Ensure that the database is ready BEFORE starting tomcat
+      # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
+      # 2. Then, run database migration to init database tables
+      # 3. Finally, start Tomcat
     entrypoint:
-    - /bin/bash
-    - '-c'
-    - |
-      while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
-      /dspace/bin/dspace database migrate
-      catalina.sh run
+      - /bin/bash
+      - '-c'
+      - |
+        while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
+        /dspace/bin/dspace database migrate
+        catalina.sh run
   # DSpace database container    
   dspacedb:
     container_name: dspacedb
@@ -73,12 +73,12 @@ services:
     networks:
       dspacenet:
     ports:
-    - published: 5432
-      target: 5432
+      - published: 5432
+        target: 5432
     stdin_open: true
     tty: true
     volumes:
-    - pgdata:/pgdata
+      - pgdata:/pgdata
   # DSpace Solr container  
   dspacesolr:
     container_name: dspacesolr
@@ -86,42 +86,41 @@ services:
     image: solr:8.11-slim
     # Needs main 'dspace' container to start first to guarantee access to solr_configs
     depends_on:
-    - dspace
+      - dspace
     networks:
       dspacenet:
     ports:
-    - published: 8983
-      target: 8983
+      - published: 8983
+        target: 8983
     stdin_open: true
     tty: true
     working_dir: /var/solr/data
     volumes:
-    # Mount our "solr_configs" volume available under the Solr's configsets folder (in a 'dspace' subfolder)
-    # This copies the Solr configs from main 'dspace' container into 'dspacesolr' via that volume
-    - solr_configs:/opt/solr/server/solr/configsets/dspace
-    # Keep Solr data directory between reboots
-    - solr_data:/var/solr/data
-    # Initialize all DSpace Solr cores using the mounted local configsets (see above), then start Solr
-    # * First, run precreate-core to create the core (if it doesn't yet exist). If exists already, this is a no-op
-    # * Second, copy updated configs from mounted configsets to this core. If it already existed, this updates core
-    #   to the latest configs. If it's a newly created core, this is a no-op.
+      # Mount our "solr_configs" volume available under the Solr's configsets folder (in a 'dspace' subfolder)
+      - solr_configs:/opt/solr/server/solr/configsets/dspace
+      # Keep Solr data directory between reboots
+      - solr_data:/var/solr/data
+      # Initialize all DSpace Solr cores using the mounted local configsets (see above), then start Solr
+      # * First, run precreate-core to create the core (if it doesn't yet exist). If exists already, this is a no-op
+      # * Second, copy updated configs from mounted configsets to this core. If it already existed, this updates core
+      #   to the latest configs. If it's a newly created core, this is a no-op.
     entrypoint:
-    - /bin/bash
-    - '-c'
-    - |
-      init-var-solr
-      precreate-core authority /opt/solr/server/solr/configsets/dspace/authority
-      cp -r -u /opt/solr/server/solr/configsets/dspace/authority/* authority
-      precreate-core oai /opt/solr/server/solr/configsets/dspace/oai
-      cp -r -u /opt/solr/server/solr/configsets/dspace/oai/* oai
-      precreate-core search /opt/solr/server/solr/configsets/dspace/search
-      cp -r -u /opt/solr/server/solr/configsets/dspace/search/* search
-      precreate-core statistics /opt/solr/server/solr/configsets/dspace/statistics
-      cp -r -u /opt/solr/server/solr/configsets/dspace/statistics/* statistics
-      exec solr -f
+      - /bin/bash
+      - '-c'
+      - |
+        init-var-solr
+        precreate-core authority /opt/solr/server/solr/configsets/dspace/authority
+        cp -r -u /opt/solr/server/solr/configsets/dspace/authority/* authority
+        precreate-core oai /opt/solr/server/solr/configsets/dspace/oai
+        cp -r -u /opt/solr/server/solr/configsets/dspace/oai/* oai
+        precreate-core search /opt/solr/server/solr/configsets/dspace/search
+        cp -r -u /opt/solr/server/solr/configsets/dspace/search/* search
+        precreate-core statistics /opt/solr/server/solr/configsets/dspace/statistics
+        cp -r -u /opt/solr/server/solr/configsets/dspace/statistics/* statistics
+        exec solr -f
 volumes:
   assetstore:
   pgdata:
-  solr_data:
-  # Special volume used to share Solr configs from 'dspace' to 'dspacesolr' container (see above)
+  solr_data: # Special volume used to share Solr configs from 'dspace' to 'dspacesolr' container (see above)
+
   solr_configs:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,10 +18,10 @@ services:
     environment:
       DSPACE_UI_SSL: "false"
       DSPACE_UI_HOST: dspace-angular
-      DSPACE_UI_PORT: "4000"
+      DSPACE_UI_PORT: "80"
       DSPACE_UI_NAMESPACE: /
       DSPACE_REST_SSL: "false"
-      DSPACE_REST_HOST: localhost
+      DSPACE_REST_HOST: "172.31.86.154"
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server
     image: dspace/dspace-angular:dspace-7_x
@@ -31,9 +31,7 @@ services:
     networks:
       dspacenet:
     ports:
-      - published: 4000
+      - published: 80
         target: 4000
-      - published: 9876
-        target: 9876
     stdin_open: true
     tty: true


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Requires DSpace/DSpace#[pr-number] (if a REST API PR is required to test this)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
